### PR TITLE
put sync with calendar buttons into a modal

### DIFF
--- a/app/views/schedules/_dog.html.erb
+++ b/app/views/schedules/_dog.html.erb
@@ -1,21 +1,14 @@
-<div class="p-3 mb-5">
+<div class="p-3 mb-3">
   <%= cl_image_tag schedule.dog.photo.key, class: 'img-fluid rounded-circle shadow', height: 200, width: 200, crop: :fill %>
   <h2 class="mb-2"><%= schedule.dog.name.capitalize%><small class="h4"></small></h2>
   <p class="mb-2"><%= schedule.dog.age_display %> old</p>
-  <div class="margin-top: auto">
-    <%= link_to download_dog_schedule_path(schedule.dog), class: "btn btn-sm btn-primary" do %>
-      <i class="far fa-calendar-alt"></i>
-      Download Calendar
-    <% end %>
-    <div class="mt-3">
-      <%= link_to "https://calendar.google.com/calendar/render?cid=#{webcal_dog_schedule_url(@schedule.dog)}", "data-controller": "webcal-sync", class:"btn btn-primary" do%>
-        <i class="far fa-calendar-alt"></i>
-        Sync to Google Calendar
-      <% end %>
-    </div>
-  </div>
 </div>
+
 <div class="d-flex flex-column">
+  <button type="button" class="btn btn-sm btn-primary" data-bs-toggle="modal" data-bs-target="#exampleModalCenter3">
+    <i class="far fa-calendar-alt"></i>
+    Sync Calendar
+  </button>
   <button type="button" class="btn btn-sm btn-outline-secondary mb-2" data-bs-toggle="modal" data-bs-target="#exampleModalCenter1">
     Vets near me
   </button>

--- a/app/views/schedules/show.html.erb
+++ b/app/views/schedules/show.html.erb
@@ -59,12 +59,10 @@
           src="https://www.google.com/maps/embed/v1/search?key=<%= ENV["GOOGLE_API_KEY"] %>&q=Veterinaria near Condesa in CDMX"
           allowfullscreen>
         </iframe>
-
       </div>
     </div>
   </div>
 </div>
-
 <div class="modal" tabindex="-1" id="exampleModalCenter2">
   <div class="modal-dialog">
     <div class="modal-content">
@@ -81,9 +79,32 @@
           src="https://www.google.com/maps/embed/v1/search?key=<%= ENV["GOOGLE_API_KEY"] %>&q=estetica canina near Condesa in CDMX"
           allowfullscreen>
         </iframe>
-
       </div>
     </div>
   </div>
 </div>
 <%= render "schedules/calendar" %>
+<div class="modal" tabindex="-1" id="exampleModalCenter3">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">Sync Calendar</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <div>
+          <%= link_to "https://calendar.google.com/calendar/render?cid=#{webcal_dog_schedule_url(@schedule.dog)}", target: :blank, "data-controller": "webcal-sync", class:"btn btn-primary" do%>
+            <i class="far fa-calendar-alt"></i>
+            Sync to Google Calendar
+          <% end %>
+        </div>
+        <div class="mt-3">
+          <%= link_to download_dog_schedule_path(@schedule.dog), class: "btn btn-sm btn-primary" do%>
+            <i class="far fa-calendar-alt"></i>
+            Download Calendar
+          <% end %>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
made it so where there are less sync buttons on schedule page and also made it so where the user can open the google calendar page in another page without having to leave the app.